### PR TITLE
Add GitHub release automation from tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Make releases from tags
+on:
+  push:
+    tags: ['[0-9]+.[0-9]+.[0-9]+*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+
+    # Source: https://medium.com/@usman_qb
+    - name: Create release body
+      id: create_release_body
+      run: |
+        RELEASEVERSION="[${{ github.ref_name }}]"
+        echo "Version: $RELEASEVERSION"
+        RELEASEBODY=$(awk -v ver="$RELEASEVERSION" '/^## / { if (p) { exit }; if ($2 == ver) { p=1; next } } p && NF' CHANGELOG.md)
+        {
+        echo 'RELEASEBODY<<EOF'
+        echo "${RELEASEBODY}"
+        echo EOF
+        } >> $GITHUB_OUTPUT
+
+    - name: Create Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "Creating release for ${{ github.ref_name }}"
+        echo "${{ steps.create_release_body.outputs.RELEASEBODY }}"
+        gh release create "${{ github.ref_name }}" --title "release_${{ github.ref_name }}" --notes "${{ steps.create_release_body.outputs.RELEASEBODY }}"
+        echo "Release created successfully"


### PR DESCRIPTION
@newpavlov @josephlr this is a cut-down version of https://github.com/rust-random/getrandom/pull/740 with only the GitHub release automation.

This assumes tags of the form "0.9.2" (no leading 'v'), which is what we've been using in rand. I have such tags from past releases ready to push after this is merged.