### PR TITLE
add `SeedableRng::fork` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove feature `os_rng`, structs `OsRng` and `OsError` and fns `from_os_rng`, `try_from_os_rng` ([#1674])
 - Remove feature `std` ([#1674])
 - Removed dependency `getrandom` ([#1674])
+- Add `SeedableRng::fork` methods ([#17])
 ### Other
 - Changed repository from [rust-random/rand] to [rust-random/core].
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1668]: https://github.com/rust-random/rand/pull/1668
 [#1669]: https://github.com/rust-random/rand/pull/1669
 [#1674]: https://github.com/rust-random/rand/pull/1674
+[#17]: https://github.com/rust-random/rand-core/pull/17
 
 [rust-random/rand]: https://github.com/rust-random/rand
 [rust-random/core]: https://github.com/rust-random/core

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,6 +488,34 @@ pub trait SeedableRng: Sized {
         rng.try_fill_bytes(seed.as_mut())?;
         Ok(Self::from_seed(seed))
     }
+
+    /// Fork this PRNG
+    ///
+    /// This creates a new PRNG from the current one by initializing a new one and
+    /// seeding it from the current one.
+    ///
+    /// This is useful when initializing a PRNG for a thread
+    fn fork(&mut self) -> Self
+    where
+        Self: RngCore,
+    {
+        Self::from_rng(self)
+    }
+
+    /// Fork this PRNG
+    ///
+    /// This creates a new PRNG from the current one by initializing a new one and
+    /// seeding it from the current one.
+    ///
+    /// This is useful when initializing a PRNG for a thread.
+    ///
+    /// This is the failable equivalent to [`SeedableRng::fork`]
+    fn try_fork(&mut self) -> Result<Self, Self::Error>
+    where
+        Self: TryRngCore,
+    {
+        Self::try_from_rng(self)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary
This provide a fork method to "clone" an Rng.

# Motivation

This is handy to initialize an Rng that needs to be given to another thread for example.

`rand_chacha` used to provide a clonable `Chacha20Rng` (arguably incorrect). `chacha20::Chacha20Rng` is not clonable. But it's convenient to fork RNGs when initializing a thread or whatnot.

# Details
