### PR TITLE
Exclude /.github from crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
 edition = "2024"
 rust-version = "1.85"
+exclude = ["/.github"]
 
 [package.metadata.docs.rs]
 # To build locally:


### PR DESCRIPTION
Without this, the `.github` dir gets included in packages. Alternatively we could just exclude issue templates.