### PR TITLE
Prepare v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - Unreleased
+## [0.10.0] - 2025-11-16
 ### API changes
 - Relax `Sized` bound on impls of `SeedableRng` ([rand#1641])
 - Move `rand_core::impls::*` to `rand_core::le` module ([rand#1667])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.10.0-rc-2"
+version = "0.10.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Prepare for v0.10.0 release. Date set to 16th (next Sunday).