### PR TITLE
Remove optional feature serde

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,8 +96,7 @@ jobs:
           cargo generate-lockfile -Z minimal-versions
       - name: Test rand_core
         run: |
-          cargo test --target ${{ matrix.target }} --no-default-features
-          cargo test --target ${{ matrix.target }} --features serde
+          cargo test --target ${{ matrix.target }}
 
   test-cross:
     runs-on: ${{ matrix.os }}
@@ -137,11 +136,9 @@ jobs:
           rustup toolchain install nightly --component miri
           rustup override set nightly
           cargo miri setup
-      - name: Test rand
+      - name: Test (miri)
         run: |
           cargo miri test
-          cargo miri test --features=serde
-          cargo miri test --no-default-features
 
   test-no-std:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove feature `os_rng`, structs `OsRng` and `OsError` and fns `from_os_rng`, `try_from_os_rng` ([rand#1674])
 - Remove feature `std` ([rand#1674])
 - Removed dependency `getrandom` ([rand#1674])
+- Removed optional dependency `serde` ([#28])
 - Add `SeedableRng::fork` methods ([#17])
 ### Other
 - Changed repository from [rust-random/rand] to [rust-random/core].
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [rand#1669]: https://github.com/rust-random/rand/pull/1669
 [rand#1674]: https://github.com/rust-random/rand/pull/1674
 [#17]: https://github.com/rust-random/rand-core/pull/17
+[#28]: https://github.com/rust-random/rand-core/pull/28
 
 [rust-random/rand]: https://github.com/rust-random/rand
 [rust-random/core]: https://github.com/rust-random/core

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,3 @@ rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.playground]
 all-features = true
-
-[features]
-serde = ["dep:serde"] # enables serde for BlockRng wrapper
-
-[dependencies]
-serde = { version = "1.0.103", features = ["derive"], optional = true }

--- a/src/block.rs
+++ b/src/block.rs
@@ -48,8 +48,6 @@
 use crate::le::fill_via_chunks;
 use crate::{CryptoRng, RngCore, SeedableRng, TryRngCore};
 use core::fmt;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 
 /// A trait for RNGs which do not generate random numbers individually, but in
 /// blocks (typically `[u32; N]`). This technique is commonly used by
@@ -108,13 +106,6 @@ pub trait CryptoBlockRng: BlockRngCore {}
 /// [`next_u64`]: RngCore::next_u64
 /// [`fill_bytes`]: RngCore::fill_bytes
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(
-        bound = "for<'x> R: Serialize + Deserialize<'x>, for<'x> R::Results: Serialize + Deserialize<'x>"
-    )
-)]
 pub struct BlockRng<R: BlockRngCore> {
     results: R::Results,
     index: usize,
@@ -273,7 +264,6 @@ impl<R: CryptoBlockRng + BlockRngCore<Item = u32>> CryptoRng for BlockRng<R> {}
 /// [`next_u64`]: RngCore::next_u64
 /// [`fill_bytes`]: RngCore::fill_bytes
 #[derive(Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BlockRng64<R: BlockRngCore + ?Sized> {
     results: R::Results,
     index: usize,


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

# Summary

Remove `serde` as an (optional) feature.

# Motivation

`rand_core` is intended to be a pure interface crate; as such it should not depend on anything else.

# Details

This doesn't affect `chacha20` since https://github.com/RustCrypto/stream-ciphers/pull/461.

It also doesn't outright prevent block-based RNGs from supporting `serde`; it is possible to write [remote adapters](https://serde.rs/remote-derive.html) for foreign types which do not support it, but allowing this would require:

- read support for `BlockRng::results` (or only the unused subset)
- read support for `BlockRng64::results`, `half_used`
- construction support for `BlockRng` and `BlockRng64` from parts

Ultimately (once `rand_core` is stable at v1.0) we could try to get this support merged into `serde` itself, but even if we don't, the loss of `serde` support for `BlockRng` should be acceptable.

# Unresolved questions

Do we want to provide some way to serialize and deserialize partial buffers?

I suggest the answer should be no: downstream RNGs already support getting/setting the stream position without this.

Exception: `BlockRng64` isn't used much. The only application of it we provide (Isaac64Rng) does not support set/get stream position. I think we shouldn't worry about it (and even consider removing it) simply due to the low usage.

# Future work

#24 can be re-evaluated independently of `serde`.