### PR TITLE
Add method fn Generator::drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed optional dependency `serde` ([#28])
 - Add `SeedableRng::fork` methods ([#17])
 - Rename trait `block::BlockRngCore` to `block::Generator` and associated type `Results` to `Output`; remove assoc. `type Item` and remove type bounds ([#26])
+- Add `fn drop` to trait `block::Generator` (#35)
+
 ### Other
 - Changed repository from [rust-random/rand] to [rust-random/core].
 
@@ -29,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#17]: https://github.com/rust-random/rand-core/pull/17
 [#26]: https://github.com/rust-random/rand-core/pull/28
 [#28]: https://github.com/rust-random/rand-core/pull/28
+[#35]: https://github.com/rust-random/rand-core/pull/35
 
 [rust-random/rand]: https://github.com/rust-random/rand
 [rust-random/core]: https://github.com/rust-random/core

--- a/src/block.rs
+++ b/src/block.rs
@@ -59,6 +59,15 @@ pub trait Generator {
     ///
     /// This must fill `output` with random data.
     fn generate(&mut self, output: &mut Self::Output);
+
+    /// Destruct the output buffer
+    ///
+    /// This method is called on [`Drop`] of the [`Self::Output`] buffer.
+    /// The default implementation does nothing.
+    #[inline]
+    fn drop(&mut self, output: &mut Self::Output) {
+        let _ = output;
+    }
 }
 
 /// A cryptographically secure generator
@@ -121,6 +130,12 @@ impl<G: Generator + fmt::Debug> fmt::Debug for BlockRng<G> {
             .field("core", &self.core)
             .field("index", &self.index)
             .finish()
+    }
+}
+
+impl<G: Generator> Drop for BlockRng<G> {
+    fn drop(&mut self) {
+        self.core.drop(&mut self.results);
     }
 }
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Add `fn drop` to trait `Generator`

# Motivation

See [this comment](https://github.com/rust-random/rand_core/pull/26#issuecomment-3629151277).

This allows the generator to add a destruction hook such as a call to zeroize the output buffer.

@baloo I think this suffices for the needs of `chacha20`?