### PR TITLE
Remove docsrs cfg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,5 @@ exclude = ["/.github"]
 
 [package.metadata.docs.rs]
 # To build locally:
-# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open
-all-features = true
+# cargo +nightly doc --open
 rustdoc-args = ["--generate-link-to-definition"]
-
-[package.metadata.playground]
-all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico"
 )]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(
     missing_docs,
     missing_debug_implementations,


### PR DESCRIPTION
# Summary

Remove `docsrs` cfg and usages of `--all-features` and `--no-deps`.

# Motivation

We don't have any features or dependencies, therefore these are unneeded.