### PR TITLE
Prepare 0.9.5: fix usage of `doc_cfg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.5] — 2026-01-13
+- Try again: `auto_cfg` -> `doc_cfg` ([#48])
+
+[#48]: https://github.com/rust-random/rand_core/pull/48
+
 ## [0.9.4] — 2026-01-12
 - Doc fix for merge of `doc_auto_cfg` into `doc_cfg` ([#46])
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand_core"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "getrandom",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
-#![cfg_attr(docsrs, feature(auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Fix up the error created in #47.