### PR TITLE
Enable lints in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,13 @@ edition = "2024"
 rust-version = "1.85"
 exclude = ["/.github"]
 
+[lints.rust]
+missing_docs = "warn"
+missing_debug_implementations = "warn"
+
+[lints.clippy]
+undocumented_unsafe_blocks = "warn"
+
 [package.metadata.docs.rs]
 # To build locally:
 # cargo +nightly doc --open

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,6 @@
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico"
 )]
-#![deny(
-    missing_docs,
-    missing_debug_implementations,
-    clippy::undocumented_unsafe_blocks
-)]
 
 use core::ops::DerefMut;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,6 +34,9 @@
 //! In many cases, [`SeedableRng::Seed`] must be converted to `[u32; _]` or
 //! `[u64; _]`. [`read_words`] may be used for this.
 //!
+//! [`SeedableRng`]: crate::SeedableRng
+//! [`SeedableRng::Seed`]: crate::SeedableRng::Seed
+//!
 //! ## Example
 //!
 //! We demonstrate a simple multiplicative congruential generator (MCG), taken
@@ -83,9 +86,8 @@
 //! # assert_eq!(buf, [154, 23, 43, 68, 75]);
 //! ```
 
+use crate::TryRng;
 pub use crate::word::Word;
-#[allow(unused)]
-use crate::{SeedableRng, TryRng};
 
 /// Generate a `u64` using `next_u32`, little-endian order.
 #[inline]

--- a/tests/block.rs
+++ b/tests/block.rs
@@ -1,3 +1,4 @@
+//! Tests for the `block` module items
 use rand_core::{
     SeedableRng,
     block::{BlockRng, Generator},

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,3 +1,4 @@
+//! Main `rand_core` tests
 use rand_core::{CryptoRng, Infallible, Rng, SeedableRng, TryCryptoRng, TryRng, UnwrapErr, utils};
 
 #[test]

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,3 +1,4 @@
+//! Tests for the `utils` module items
 use rand_core::{Infallible, Rng, TryRng, utils};
 
 struct DummyRng(u32);


### PR DESCRIPTION
Additionally removes `#[allow(unused)]` from the `utils` module.