### PR TITLE
Remove CryptoGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BlockRng::reset` method ([#44])
 - `BlockRng::index` method (replaced with `BlockRng::word_offset`) ([#44])
 - `Generator::Item` associated type ([#26])
+- `CryptoBlockRng` ([#69])
 
 [0.10.0]: https://github.com/rust-random/rand_core/compare/v0.9.3...HEAD
 
@@ -60,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#53]: https://github.com/rust-random/rand_core/pull/53
 [#56]: https://github.com/rust-random/rand_core/pull/56
 [#58]: https://github.com/rust-random/rand_core/pull/58
+[#69]: https://github.com/rust-random/rand_core/pull/69
 
 [rust-random/rand]: https://github.com/rust-random/rand
 [rust-random/rand_core]: https://github.com/rust-random/rand_core

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,8 +1,7 @@
 //! The [`Generator`] trait and [`BlockRng`]
 //!
-//! Trait [`Generator`] and marker trait [`CryptoGenerator`] may be implemented
-//! by block-generators; that is PRNGs whose output is a *block* of words, such
-//! as `[u32; 16]`.
+//! Trait [`Generator`] may be implemented by block-generators; that is PRNGs
+//! whose output is a *block* of words, such as `[u32; 16]`.
 //!
 //! The struct [`BlockRng`] wraps such a [`Generator`] together with an output
 //! buffer and implements several methods (e.g. [`BlockRng::next_word`]) to
@@ -72,17 +71,8 @@
 //! # assert_eq!(rng.next_u32(), 1171109249);
 //! ```
 //!
-//! # ReseedingRng
-//!
-//! The [`Generator`] trait supports usage of [`rand::rngs::ReseedingRng`].
-//! This requires that [`SeedableRng`] be implemented on the "core" generator.
-//! Additionally, it may be useful to implement [`CryptoGenerator`].
-//! (This is in addition to any implementations on an [`TryRng`] type.)
-//!
-//! [`Generator`]: crate::block::Generator
 //! [`TryRng`]: crate::TryRng
 //! [`SeedableRng`]: crate::SeedableRng
-//! [`rand::rngs::ReseedingRng`]: https://docs.rs/rand/latest/rand/rngs/struct.ReseedingRng.html
 
 use crate::utils::Word;
 use core::fmt;
@@ -108,18 +98,6 @@ pub trait Generator {
         let _ = output;
     }
 }
-
-/// A cryptographically secure generator
-///
-/// This is a marker trait used to indicate that a [`Generator`] implementation
-/// is supposed to be cryptographically secure.
-///
-/// Mock generators should not implement this trait *except* under a
-/// `#[cfg(test)]` attribute to ensure that mock "crypto" generators cannot be
-/// used in production.
-///
-/// See [`TryCryptoRng`](crate::TryCryptoRng) docs for more information.
-pub trait CryptoGenerator: Generator {}
 
 /// RNG functionality for a block [`Generator`]
 ///


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Motivation

Removes `CryptoGenerator` since https://github.com/rust-random/rand/pull/1722 makes it useless.

Removes fn `Generator::drop` since it can be confusing.

Adds fn `BlockRng::clear` explicitly for use with zeroize, since it is clear we do need to care about that and an explicit method appears to be the best solution (without actually depending on the zeroize crate).

Soft-blocker: chacha20 will need a new zeroize release to use `clear` correctly.