### PR TITLE
Add deprecated `RngCore`/`TryRngCore` forwarding traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,3 +249,24 @@ where
 pub trait TryCryptoRng: TryRng {}
 
 impl<R: DerefMut> TryCryptoRng for R where R::Target: TryCryptoRng {}
+
+/// DEPRECATED: stub trait to print a deprecation warning and aid discovering that [`Rng`] is the
+/// replacement.
+// TODO: remove prior to v1.x.
+#[deprecated(since = "0.10.0", note = "use `Rng` instead")]
+pub trait RngCore: Rng {}
+#[allow(deprecated)]
+impl<R: Rng> RngCore for R {}
+
+/// DEPRECATED: stub trait to print a deprecation warning and aid discovering that [`TryRng`] is the
+/// replacement.
+// TODO: remove prior to v1.x.
+#[deprecated(since = "0.10.0", note = "use `TryRng` instead")]
+pub trait TryRngCore: TryRng {
+    /// Error type.
+    type Error: core::error::Error;
+}
+#[allow(deprecated)]
+impl<R: TryRng> TryRngCore for R {
+    type Error = R::Error;
+}


### PR DESCRIPTION
Since `RngCore` has been renamed to `Rng`, and `TryRngCore` to `TryRng`, this adds some deprecated stub traits with the old names that have a `note` about the new names.

They have supertrait bounds on the new names, along with blanket impls for the new names:

- `RngCore: Rng`
- `TryRngCore: TryRng`

These can be released in v0.10.x and removed before v1.x.

Though they don't have any methods, due to an odd quirk of how Rust resolves methods in a generic context (effectively uniting a trait and all of its supertraits into a single logical method table), the methods of the new traits are callable from a generic context even without the new traits in the bounds or even in scope whatsoever:

```rust
use rand_core::RngCore;

pub fn foo<R: RngCore>(mut rng: R) -> [u8; 8] {
    let mut ret = [0u8; 8];
    rng.fill_bytes(&mut ret);
    ret
}
```

This will actually compile with the following warnings:

```
warning: use of deprecated trait `rand_core::RngCore`: use `Rng` instead
 --> src/main.rs:1:16
  |
1 | use rand_core::RngCore;
  |                ^^^^^^^
  |
  = note: `#[warn(deprecated)]` on by default

warning: use of deprecated trait `rand_core::RngCore`: use `Rng` instead
 --> src/main.rs:3:15
  |
3 | pub fn foo<R: RngCore>(mut rng: R) -> [u8; 8] {
  |               ^^^^^^^
```

I think this will help people upgrade because it will allow a significant amount of code to continue to compile while also informing people of the new names and what code needs to be changed.