### PR TITLE
Add `next_u128` and `try_next_u128` to `Rng` and `TryRng` respectively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - TBD
+### API changes
+- Add `next_u128` and `try_next_u128` to `Rng` and `TryRng` respectively.
+[0.11.0]
+
+
 ## [0.10.1] - 2026-04-13
 
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ pub trait TryRng {
         // over reducing calls to generate numbers
         let lo = self.try_next_u64().map(u128::from);
         let hi = self.try_next_u64().map(u128::from);
-        match (lo, hi) => {
+        match (lo, hi) {
             (Ok(lo), Ok(hi)) => Ok(lo + (hi << 64)),
             (lo, hi) => core::hint::selct_unpredictable(lo.is_err(), lo, hi)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ pub trait TryRng {
         let hi = self.try_next_u64().map(u128::from);
         match (lo, hi) {
             (Ok(lo), Ok(hi)) => Ok(lo + (hi << 64)),
-            (lo, hi) => core::hint::selct_unpredictable(lo.is_err(), lo, hi)
+            (lo, hi) => core::hint::select_unpredictable(lo.is_err(), lo, hi)
         }
     }
     

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,13 @@ pub trait Rng: TryRng<Error = Infallible> {
     /// Return the next random `u64`.
     fn next_u64(&mut self) -> u64;
 
+    /// Return the next random `u128`.
+    fn next_u128(&mut self) -> u128 {
+        let lo = self.next_u64() as u128;
+        let hi = self.next_u64() as u128;
+        lo + (hi << 64)
+    }
+
     /// Fill `dest` with random data.
     ///
     /// This method should guarantee that `dest` is entirely filled
@@ -196,6 +203,18 @@ pub trait TryRng {
     fn try_next_u32(&mut self) -> Result<u32, Self::Error>;
     /// Return the next random `u64`.
     fn try_next_u64(&mut self) -> Result<u64, Self::Error>;
+    /// Return the next random `u128`.
+    fn try_next_u128(&mut self) -> Result<u128, Self::Error> {
+        // this implementation prioritizes reducing branching
+        // over reducing calls to generate numbers
+        let lo = self.try_next_u64().map(u128::from);
+        let hi = self.try_next_u64().map(u128::from);
+        match (lo, hi) => {
+            (Ok(lo), Ok(hi)) => Ok(lo + (hi << 64)),
+            (lo, hi) => core::hint::selct_unpredictable(lo.is_err(), lo, hi)
+        }
+    }
+    
     /// Fill `dst` entirely with random data.
     fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary
Added methods to `Rng` and `TryRng` to for direct generation of u128s.

# Motivation
See: #77

# Details
Functions `next_u128` and `try_next_u128` that generate a u128.
To ensure backwards-compatibility a default implementation was 
added that works by concating 2 u64s generated from calls to 
`(try_)next_u64`. The implementation for `try_next_u128` prioritizes
reducing branching over reducing calls to `try_next_u64`.