### PR TITLE
[Breaking draft] Tweak `block::Generator` to support fast-key-erasure

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -26,9 +26,10 @@
 //!     type Word = u32;
 //!     type Output = [u32; 8];
 //!
-//!     fn generate(&mut self, output: &mut Self::Output) {
+//!     fn generate(&mut self, output: &mut Self::Output) -> usize {
 //!         // Write a new block to output...
 //! #        *output = self.state;
+//! #        0
 //!     }
 //! }
 //!
@@ -90,8 +91,10 @@ pub trait Generator {
 
     /// Generate a new block of `output`.
     ///
-    /// This must fill `output` with random data.
-    fn generate(&mut self, output: &mut Self::Output);
+    /// This must fill `output` with random data and return the first usable
+    /// index. The return value must be less than the length.
+    #[must_use]
+    fn generate(&mut self, output: &mut Self::Output) -> usize;
 
     /// Erase results from the output buffer
     ///
@@ -197,9 +200,10 @@ impl<W: Word, const N: usize, G: Generator<Word = W, Output = [W; N]>> BlockRng<
             return;
         }
 
-        assert!(n < N);
-        self.core.generate(&mut self.results);
-        self.set_index(n);
+        let index = self.core.generate(&mut self.results);
+        let index = index.max(n);
+        assert!(index < N);
+        self.set_index(index);
     }
 
     /// Get the number of words consumed since the start of the block
@@ -217,8 +221,8 @@ impl<W: Word, const N: usize, G: Generator<Word = W, Output = [W; N]>> BlockRng<
     pub fn next_word(&mut self) -> W {
         let mut index = self.index();
         if index >= N {
-            self.core.generate(&mut self.results);
-            index = 0;
+            index = self.core.generate(&mut self.results);
+            assert!(index < N);
         }
 
         let value = self.results[index];
@@ -242,13 +246,14 @@ impl<const N: usize, G: Generator<Word = u32, Output = [u32; N]>> BlockRng<G> {
             G::erase(&mut self.results[index..new_index]);
         } else {
             lo = self.results[N - 1];
-            self.core.generate(&mut self.results);
-            hi = self.results[0];
-            new_index = 1;
+            new_index = self.core.generate(&mut self.results);
+            assert!(new_index + 1 < N);
+            hi = self.results[new_index];
+            new_index += 1;
             if index >= N {
                 lo = hi;
-                hi = self.results[1];
-                new_index = 2;
+                hi = self.results[new_index];
+                new_index += 1;
             }
             G::erase(&mut self.results[0..new_index]);
         }
@@ -265,8 +270,8 @@ impl<W: Word, const N: usize, G: Generator<Word = W, Output = [W; N]>> BlockRng<
         let mut index = self.index();
         while read_len < dest.len() {
             if index >= N {
-                self.core.generate(&mut self.results);
-                index = 0;
+                index = self.core.generate(&mut self.results);
+                assert!(index < N);
             }
 
             let size = core::mem::size_of::<W>();

--- a/src/block.rs
+++ b/src/block.rs
@@ -92,7 +92,8 @@ pub trait Generator {
     /// Destruct the output buffer
     ///
     /// This method is called on [`Drop`] of the [`Self::Output`] buffer.
-    /// The default implementation does nothing.
+    /// The default implementation does nothing; an overriding implementation
+    /// might be used to (securely) erase results.
     #[inline]
     fn drop(&mut self, output: &mut Self::Output) {
         let _ = output;
@@ -129,6 +130,7 @@ where
     }
 }
 
+/// Calls [`Generator::drop`] on the output buffer
 impl<G: Generator> Drop for BlockRng<G> {
     fn drop(&mut self) {
         self.core.drop(&mut self.results);

--- a/src/block.rs
+++ b/src/block.rs
@@ -93,6 +93,17 @@ pub trait Generator {
     /// This must fill `output` with random data.
     fn generate(&mut self, output: &mut Self::Output);
 
+    /// Erase results from the output buffer
+    ///
+    /// This method is called after values from the buffer are consumed and
+    /// before the buffer is deconstructed.
+    /// The default implementation does nothing; an overriding implementation
+    /// might be used for fast erasure of consumed values.
+    #[inline]
+    fn erase(slice: &mut [Self::Word]) {
+        let _ = slice;
+    }
+
     /// Destruct the output buffer
     ///
     /// This method is called on [`Drop`] of the [`Self::Output`] buffer.
@@ -211,6 +222,7 @@ impl<W: Word, const N: usize, G: Generator<Word = W, Output = [W; N]>> BlockRng<
         }
 
         let value = self.results[index];
+        G::erase(&mut self.results[index..index + 1]);
         self.set_index(index + 1);
         value
     }
@@ -227,6 +239,7 @@ impl<const N: usize, G: Generator<Word = u32, Output = [u32; N]>> BlockRng<G> {
             lo = self.results[index];
             hi = self.results[index + 1];
             new_index = index + 2;
+            G::erase(&mut self.results[index..new_index]);
         } else {
             lo = self.results[N - 1];
             self.core.generate(&mut self.results);
@@ -237,6 +250,7 @@ impl<const N: usize, G: Generator<Word = u32, Output = [u32; N]>> BlockRng<G> {
                 hi = self.results[1];
                 new_index = 2;
             }
+            G::erase(&mut self.results[0..new_index]);
         }
         self.set_index(new_index);
         (u64::from(hi) << 32) | u64::from(lo)
@@ -277,6 +291,8 @@ impl<W: Word, const N: usize, G: Generator<Word = W, Output = [W; N]>> BlockRng<
                 break;
             }
         }
+
+        G::erase(&mut self.results[0..index]);
         self.set_index(index);
     }
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -23,6 +23,7 @@
 //! }
 //!
 //! impl Generator for MyRngCore {
+//!     type Word = u32;
 //!     type Output = [u32; 8];
 //!
 //!     fn generate(&mut self, output: &mut Self::Output) {
@@ -79,9 +80,12 @@ use core::fmt;
 
 /// A random (block) generator
 pub trait Generator {
+    /// The word type.
+    type Word: Word;
+
     /// The output type.
     ///
-    /// For use with [`rand_core::block`](crate::block) code this must be `[u32; _]` or `[u64; _]`.
+    /// For use with [`rand_core::block`](crate::block) code this must be `[Self::Word; _]`.
     type Output;
 
     /// Generate a new block of `output`.
@@ -137,7 +141,7 @@ impl<G: Generator> Drop for BlockRng<G> {
     }
 }
 
-impl<W: Word + Default, const N: usize, G: Generator<Output = [W; N]>> BlockRng<G> {
+impl<W: Word + Default, const N: usize, G: Generator<Word = W, Output = [W; N]>> BlockRng<G> {
     /// Create a new `BlockRng` from an existing RNG implementing
     /// `Generator`. Results will be generated on first use.
     #[inline]
@@ -148,7 +152,7 @@ impl<W: Word + Default, const N: usize, G: Generator<Output = [W; N]>> BlockRng<
     }
 }
 
-impl<W: Word, const N: usize, G: Generator<Output = [W; N]>> BlockRng<G> {
+impl<W: Word, const N: usize, G: Generator<Word = W, Output = [W; N]>> BlockRng<G> {
     /// Get the index into the result buffer.
     ///
     /// If this is equal to or larger than the size of the result buffer then
@@ -212,7 +216,7 @@ impl<W: Word, const N: usize, G: Generator<Output = [W; N]>> BlockRng<G> {
     }
 }
 
-impl<const N: usize, G: Generator<Output = [u32; N]>> BlockRng<G> {
+impl<const N: usize, G: Generator<Word = u32, Output = [u32; N]>> BlockRng<G> {
     /// Generate a `u64` from two `u32` words
     #[inline]
     pub fn next_u64_from_u32(&mut self) -> u64 {
@@ -239,7 +243,7 @@ impl<const N: usize, G: Generator<Output = [u32; N]>> BlockRng<G> {
     }
 }
 
-impl<W: Word, const N: usize, G: Generator<Output = [W; N]>> BlockRng<G> {
+impl<W: Word, const N: usize, G: Generator<Word = W, Output = [W; N]>> BlockRng<G> {
     /// Fill `dest`
     #[inline]
     pub fn fill_bytes(&mut self, dest: &mut [u8]) {

--- a/src/block.rs
+++ b/src/block.rs
@@ -144,24 +144,6 @@ impl<W: Word + Default, const N: usize, G: Generator<Output = [W; N]>> BlockRng<
         results[0] = W::from_usize(N);
         BlockRng { core, results }
     }
-
-    /// Reconstruct from a core and a remaining-results buffer.
-    ///
-    /// This may be used to deserialize using a `core` and the output of
-    /// [`Self::remaining_results`].
-    ///
-    /// Returns `None` if `remaining_results` is too long.
-    pub fn reconstruct(core: G, remaining_results: &[W]) -> Option<Self> {
-        let mut results = [W::default(); N];
-        if remaining_results.len() < N {
-            let index = N - remaining_results.len();
-            results[index..].copy_from_slice(remaining_results);
-            results[0] = W::from_usize(index);
-            Some(BlockRng { results, core })
-        } else {
-            None
-        }
-    }
 }
 
 impl<W: Word, const N: usize, G: Generator<Output = [W; N]>> BlockRng<G> {
@@ -211,20 +193,6 @@ impl<W: Word, const N: usize, G: Generator<Output = [W; N]>> BlockRng<G> {
     pub fn word_offset(&self) -> usize {
         let index = self.index();
         if index >= N { 0 } else { index }
-    }
-
-    /// Access the unused part of the results buffer
-    ///
-    /// The length of the returned slice is guaranteed to be less than the
-    /// length of `<Self as Generator>::Output` (i.e. less than `N` where
-    /// `Output = [W; N]`).
-    ///
-    /// This is a low-level interface intended for serialization.
-    /// Results are not marked as consumed.
-    #[inline]
-    pub fn remaining_results(&self) -> &[W] {
-        let index = self.index();
-        &self.results[index..]
     }
 
     /// Generate the next word (e.g. `u32`)

--- a/tests/block.rs
+++ b/tests/block.rs
@@ -12,6 +12,7 @@ struct DummyRng {
 }
 
 impl Generator for DummyRng {
+    type Word = u32;
     type Output = [u32; RESULTS_LEN];
 
     fn generate(&mut self, output: &mut Self::Output) {

--- a/tests/block.rs
+++ b/tests/block.rs
@@ -15,11 +15,12 @@ impl Generator for DummyRng {
     type Word = u32;
     type Output = [u32; RESULTS_LEN];
 
-    fn generate(&mut self, output: &mut Self::Output) {
+    fn generate(&mut self, output: &mut Self::Output) -> usize {
         for item in output {
             *item = self.counter;
             self.counter = self.counter.wrapping_add(3511615421);
         }
+        0
     }
 }
 


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

# Summary

Tweak the `block::Generator` trait to support fast-key-erasure: https://github.com/RustCrypto/stream-ciphers/pull/578

Also removes `BlockRng::{reconstruct, remaining_results}` since to my knowledge these are only used by the (mostly abandoned) Isaac generators.

# Motivation

It turns out we can fit a low-overhead fast-key-erasure generator into our existing ecosystem with only some small tweaks here. (Larger changes to the `block` code may be warranted; this is more a proof-of-concept with minimal changes.)

# Details

- Add associated type `Generator::Word`. Note that we require (without trait bound) that `Generator::Output` is `[Word; N]` for some `N` and that `N` is not currently an associated constant; ideally we'd add `N` and remove `Output` but this requires improved const generics support IIRC.
- Add fn `Generator::erase`. Note that this does a different job to `drop`: `erase` is used for fast-erasure (only, and without feature requirements) while `drop` is used to `zeroize` the buffer on drop (if that feature is enabled).
- Make fn `Generator::generate` return the index of the first available value in the buffer.